### PR TITLE
Fixing header formatting so header is inside orange

### DIFF
--- a/frontend/src/grant-info/components/GrantLabels.tsx
+++ b/frontend/src/grant-info/components/GrantLabels.tsx
@@ -18,7 +18,7 @@ const GrantLabels: React.FC<{
   }
 
   return (
-    <ul className="grant-labels grid grid-cols-4 justify-stretch font-semibold p-4">
+    <ul className="grant-labels grid grid-cols-4 justify-stretch font-semibold pt-4">
       <li className="text-center">
         <button
           className="grant-name"

--- a/frontend/src/grant-info/components/GrantList.tsx
+++ b/frontend/src/grant-info/components/GrantList.tsx
@@ -104,13 +104,14 @@ const GrantList: React.FC = observer(() => {
       */}
       <PaginationRoot defaultPage={1} count={totalPages}>
         {/* Actual grants for the current page */}
+        <div className="bg-light-orange rounded-[1.2rem] pt-2">
         <GrantLabels onSort={HandleHeaderClick} />
-        <div className="grant-list p-4">
+        <div className="grant-list p-4 ">
         {grants.map(grant => (
           <GrantItem key={grant.grantId} grant={grant} />
         ))}
         </div>
-
+        </div>
         {/* 
            Paging Controls:
             - Prev / Next triggers


### PR DESCRIPTION
Fixing header formatting on grant list so that it is inside the orange section, matching the Figma