### PR TITLE
Unit Tests for Grants

### DIFF
--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -83,6 +83,9 @@ describe("GrantService", () => {
     // Clear all mocks before each test
     vi.clearAllMocks();
 
+    // Set the environment variable for the table name
+    process.env.DYNAMODB_GRANT_TABLE_NAME = 'Grants';
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [GrantController],
       providers: [GrantService],

--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -4,7 +4,6 @@ import { GrantService } from "../grant.service";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Grant } from "../../types/Grant";
 import { NotFoundException } from "@nestjs/common";
-import { UpdateExpression } from "ts-morph";
 
 enum Status {
   Potential = "Potential",
@@ -190,6 +189,45 @@ describe("GrantService", () => {
       await expect(grantService.unarchiveGrants([90])).rejects.toThrow(
         "Failed to update Grant 90 status."
       );
+    });
+  });
+
+  describe("updateGrant()", () => {
+    it("should update the correct grant and return a stringified JSON with the updated grant", async () => {
+      const mockUpdatedGrant: Grant = {
+        grantId: 2,
+        organization: mockGrants[1].organization,
+        does_bcan_qualify: true, // UPDATED
+        status: Status.Active, // UPDATED
+        amount: mockGrants[1].amount,
+        application_deadline: mockGrants[1].application_deadline,
+        report_deadline: mockGrants[1].report_deadline,
+        notification_date: mockGrants[1].notification_date,
+        description: mockGrants[1].description,
+        application_requirements: mockGrants[1].application_requirements,
+        additional_notes: "Even MORE notes", // UPDATED
+        timeline: mockGrants[1].timeline,
+        estimated_completion_time: 400, // UPDATED
+        grantmaker_poc: mockGrants[1].grantmaker_poc,
+        attachments: mockGrants[1].attachments,
+      };
+      const updatedAttributes = {
+        does_bcan_qualify: mockUpdatedGrant.does_bcan_qualify,
+        status: mockUpdatedGrant.status,
+        additional_notes: mockUpdatedGrant.additional_notes,
+        estimated_completion_time: mockUpdatedGrant.estimated_completion_time,
+      };
+
+      mockUpdate.mockReturnValue({
+        promise: vi.fn().mockResolvedValue({ Attributes: updatedAttributes })
+      });
+
+      const data = await grantService.updateGrant(mockUpdatedGrant);
+
+      expect(data).toEqual(JSON.stringify({
+        Attributes: updatedAttributes
+      }));
+      expect(mockGrants[0]).toEqual(mockGrants[0]);
     });
   });
 });

--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -4,6 +4,7 @@ import { GrantService } from "../grant.service";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Grant } from "../../types/Grant";
 import { NotFoundException } from "@nestjs/common";
+import { UpdateExpression } from "ts-morph";
 
 enum Status {
   Potential = "Potential",
@@ -54,10 +55,12 @@ const mockGrants: Grant[] = [
 const mockPromise = vi.fn();
 const mockScan = vi.fn().mockReturnThis();
 const mockGet = vi.fn().mockReturnThis();
+const mockUpdate = vi.fn().mockReturnThis();
 
 const mockDocumentClient = {
   scan: mockScan,
   get: mockGet,
+  update: mockUpdate,
   promise: mockPromise,
 };
 
@@ -129,11 +132,63 @@ describe("GrantService", () => {
     });
 
     it("should throw an error if given an invalid id", async () => {
-      const noGrantFoundError = new NotFoundException("No grant with id 5 found.");
+      const noGrantFoundError = new NotFoundException(
+        "No grant with id 5 found."
+      );
       mockPromise.mockRejectedValue(noGrantFoundError);
 
       expect(grantService.getGrantById(5)).rejects.toThrow(
         "No grant with id 5 found."
+      );
+    });
+  });
+
+  describe("unarchiveGrants()", () => {
+    it("should unarchive multiple grants and return their ids", async () => {
+      mockPromise
+        .mockResolvedValueOnce({ Attributes: { isArchived: false } })
+        .mockResolvedValueOnce({ Attributes: { isArchived: false } });
+
+      const data = await grantService.unarchiveGrants([1, 2]);
+
+      expect(data).toEqual([1, 2]);
+      expect(mockUpdate).toHaveBeenCalledTimes(2);
+
+      const firstCallArgs = mockUpdate.mock.calls[0][0];
+      const secondCallArgs = mockUpdate.mock.calls[1][0];
+
+      expect(firstCallArgs).toMatchObject({
+        TableName: "Grants",
+        Key: { grantId: 1 },
+        UpdateExpression: "set isArchived = :archived",
+        ExpressionAttributeValues: { ":archived": false },
+        ReturnValues: "UPDATED_NEW",
+      });
+      expect(secondCallArgs).toMatchObject({
+        TableName: "Grants",
+        Key: { grantId: 2 },
+        UpdateExpression: "set isArchived = :archived",
+        ExpressionAttributeValues: { ":archived": false },
+        ReturnValues: "UPDATED_NEW",
+      });
+    });
+
+    it("should skip over grants that are already ", async () => {
+      mockPromise
+        .mockResolvedValueOnce({ Attributes: { isArchived: true } })
+        .mockResolvedValueOnce({ Attributes: { isArchived: false } });
+
+      const data = await grantService.unarchiveGrants([1, 2]);
+
+      expect(data).toEqual([2]);
+      expect(mockUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw an error if any update call fails", async () => {
+      mockPromise.mockRejectedValueOnce(new Error("DB Error"));
+
+      await expect(grantService.unarchiveGrants([90])).rejects.toThrow(
+        "Failed to update Grant 90 status."
       );
     });
   });

--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -302,13 +302,15 @@ describe("GrantService", () => {
         attachments: [],
       };
 
+      const now = Date.now()
+
       mockPut.mockReturnValue({
-        promise: vi.fn().mockResolvedValue(Date.now()),
+        promise: vi.fn().mockResolvedValue(now),
       });
 
       const data = await grantService.addGrant(mockCreateGrantDto);
 
-      expect(data).toEqual(Date.now());
+      expect(data).toEqual(now);
       expect(mockDocumentClient.put).toHaveBeenCalledWith({
         TableName: expect.any(String),
         Item: {

--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -104,6 +104,9 @@ describe("GrantService", () => {
       const data = await grantService.getAllGrants();
 
       expect(data).toEqual(mockGrants);
+      expect(mockDocumentClient.scan).toHaveBeenCalledWith({
+        TableName: expect.any(String)
+      })
     });
 
     it("should return an empty list of grants if no grants exist in the database", async () => {
@@ -131,6 +134,12 @@ describe("GrantService", () => {
       const data = await grantService.getGrantById(1);
 
       expect(data).toEqual(mockGrants[0]);
+      expect(mockDocumentClient.get).toHaveBeenCalledWith({
+        TableName: expect.any(String),
+        Key: {
+          grantId: 1
+        }
+      })
     });
 
     it("should throw an error if given an invalid id", async () => {
@@ -233,6 +242,14 @@ describe("GrantService", () => {
         })
       );
       expect(mockGrants[0]).toEqual(mockGrants[0]);
+      expect(mockDocumentClient.update).toHaveBeenCalledWith({
+        TableName: expect.any(String),
+        Key: { grantId: 2 },
+        UpdateExpression: expect.any(String),
+        ExpressionAttributeNames: expect.any(Object),
+        ExpressionAttributeValues: expect.any(Object),
+        ReturnValues: "UPDATED_NEW"
+      })
     });
 
     it("should throw an error if the updated grant has an invalid id", async () => {
@@ -268,7 +285,8 @@ describe("GrantService", () => {
     it("should successfully add a grant and return the new grant id", async () => {
       const mockCreateGrantDto: CreateGrantDto = {
         organization: "New test organization",
-        description: "This is a new organization that does organizational things",
+        description:
+          "This is a new organization that does organizational things",
         grantmaker_poc: ["newtestorg@test.com"],
         application_deadline: "2026-02-14",
         report_deadline: "2026-11-05",
@@ -279,10 +297,10 @@ describe("GrantService", () => {
         status: Status.Potential,
         amount: 35000,
         attachments: [],
-      }
+      };
 
       mockPut.mockReturnValue({
-        promise: vi.fn().mockResolvedValue(Date.now())
+        promise: vi.fn().mockResolvedValue(Date.now()),
       });
 
       const data = await grantService.addGrant(mockCreateGrantDto);
@@ -292,10 +310,10 @@ describe("GrantService", () => {
         TableName: expect.any(String),
         Item: {
           grantId: expect.any(Number),
-          ...mockCreateGrantDto
-        }
-      })
-    })
+          ...mockCreateGrantDto,
+        },
+      });
+    });
 
     it("should throw an error if the database put operation fails", async () => {
       const mockCreateGrantDto = {
@@ -318,6 +336,6 @@ describe("GrantService", () => {
       await expect(grantService.addGrant(mockCreateGrantDto)).rejects.toThrow(
         "Failed to upload new grant from New Org"
       );
-    })
-  })
+    });
+  });
 });

--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -3,6 +3,7 @@ import { GrantController } from "../grant.controller";
 import { GrantService } from "../grant.service";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Grant } from "../../types/Grant";
+import { NotFoundException } from "@nestjs/common";
 
 enum Status {
   Potential = "Potential",
@@ -118,7 +119,22 @@ describe("GrantService", () => {
     });
   });
 
-  it("Test", async () => {
-    expect(true).toBe(true);
+  describe("getGrantById()", () => {
+    it("should return the correct grant given a valid id", async () => {
+      mockPromise.mockResolvedValue({ Item: mockGrants[0] });
+
+      const data = await grantService.getGrantById(1);
+
+      expect(data).toEqual(mockGrants[0]);
+    });
+
+    it("should throw an error if given an invalid id", async () => {
+      const noGrantFoundError = new NotFoundException("No grant with id 5 found.");
+      mockPromise.mockRejectedValue(noGrantFoundError);
+
+      expect(grantService.getGrantById(5)).rejects.toThrow(
+        "No grant with id 5 found."
+      );
+    });
   });
 });

--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -229,5 +229,31 @@ describe("GrantService", () => {
       }));
       expect(mockGrants[0]).toEqual(mockGrants[0]);
     });
+
+    it("should throw an error if the updated grant has an invalid id", async () => {
+      const mockUpdatedGrant: Grant = {
+        grantId: 90,
+        organization: mockGrants[1].organization,
+        does_bcan_qualify: true, // UPDATED
+        status: Status.Active, // UPDATED
+        amount: mockGrants[1].amount,
+        application_deadline: mockGrants[1].application_deadline,
+        report_deadline: mockGrants[1].report_deadline,
+        notification_date: mockGrants[1].notification_date,
+        description: mockGrants[1].description,
+        application_requirements: mockGrants[1].application_requirements,
+        additional_notes: "Even MORE notes", // UPDATED
+        timeline: mockGrants[1].timeline,
+        estimated_completion_time: 400, // UPDATED
+        grantmaker_poc: mockGrants[1].grantmaker_poc,
+        attachments: mockGrants[1].attachments,
+      };
+
+      mockUpdate.mockRejectedValue({
+        promise: vi.fn().mockRejectedValue(new Error())
+      });
+
+      await expect(grantService.updateGrant(mockUpdatedGrant)).rejects.toThrow(new Error("Failed to update Grant 90"))
+    })
   });
 });

--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -1,7 +1,53 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { GrantController } from '../grant.controller';
-import { GrantService } from '../grant.service';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Test, TestingModule } from "@nestjs/testing";
+import { GrantController } from "../grant.controller";
+import { GrantService } from "../grant.service";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Grant } from "../../types/Grant";
+
+enum Status {
+  Potential = "Potential",
+  Active = "Active",
+  Inactive = "Inactive",
+  Rejected = "Rejected",
+  Pending = "Pending",
+}
+
+const mockGrants: Grant[] = [
+  {
+    grantId: 1,
+    organization: "Test Organization",
+    does_bcan_qualify: true,
+    status: Status.Potential,
+    amount: 1000,
+    application_deadline: "2025-01-01",
+    report_deadline: "2025-01-01",
+    notification_date: "2025-01-01",
+    description: "Test Description",
+    application_requirements: "Test Application Requirements",
+    additional_notes: "Test Additional Notes",
+    timeline: 1,
+    estimated_completion_time: 100,
+    grantmaker_poc: ["test@test.com"],
+    attachments: [],
+  },
+  {
+    grantId: 2,
+    organization: "Test Organization 2",
+    does_bcan_qualify: false,
+    status: Status.Potential,
+    amount: 1000,
+    application_deadline: "2025-02-01",
+    report_deadline: "2025-03-01",
+    notification_date: "2025-03-10",
+    description: "Test Description 2",
+    application_requirements: "More application requirements",
+    additional_notes: "More notes",
+    timeline: 2,
+    estimated_completion_time: 300,
+    grantmaker_poc: ["test2@test.com"],
+    attachments: [],
+  },
+];
 
 // Create mock functions that we can reference
 const mockPromise = vi.fn();
@@ -14,18 +60,16 @@ const mockDocumentClient = {
   promise: mockPromise,
 };
 
-
-
 // Mock AWS SDK - Note the structure here
-vi.mock('aws-sdk', () => ({
+vi.mock("aws-sdk", () => ({
   default: {
     DynamoDB: {
-      DocumentClient: vi.fn(() => mockDocumentClient)
-    }
-  }
+      DocumentClient: vi.fn(() => mockDocumentClient),
+    },
+  },
 }));
 
-describe('NotificationController', () => {
+describe("GrantService", () => {
   let controller: GrantController;
   let grantService: GrantService;
 
@@ -42,16 +86,39 @@ describe('NotificationController', () => {
     grantService = module.get<GrantService>(GrantService);
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(controller).toBeDefined();
     expect(grantService).toBeDefined();
   });
 
-  it('Test', async () => {
-    expect(true).toBe(true);
+  describe("getAllGrants()", () => {
+    it("should return a populated list of grants", async () => {
+      mockPromise.mockResolvedValue({ Items: mockGrants });
+
+      const data = await grantService.getAllGrants();
+
+      expect(data).toEqual(mockGrants);
+    });
+
+    it("should return an empty list of grants if no grants exist in the database", async () => {
+      mockPromise.mockResolvedValue({ Items: [] });
+
+      const data = await grantService.getAllGrants();
+
+      expect(data).toEqual([]);
+    });
+
+    it("should throw an error if there is an issue retrieving the grants", async () => {
+      const dbError = new Error("Could not retrieve grants");
+      mockPromise.mockRejectedValue(dbError);
+
+      expect(grantService.getAllGrants()).rejects.toThrow(
+        "Could not retrieve grants"
+      );
+    });
   });
 
-  it('Test', async () => {
+  it("Test", async () => {
     expect(true).toBe(true);
   });
 });

--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -4,6 +4,7 @@ import { GrantService } from "../grant.service";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Grant } from "../../types/Grant";
 import { NotFoundException } from "@nestjs/common";
+import { CreateGrantDto } from "../dto/create-grant.dto";
 
 enum Status {
   Potential = "Potential",
@@ -55,12 +56,14 @@ const mockPromise = vi.fn();
 const mockScan = vi.fn().mockReturnThis();
 const mockGet = vi.fn().mockReturnThis();
 const mockUpdate = vi.fn().mockReturnThis();
+const mockPut = vi.fn().mockReturnThis();
 
 const mockDocumentClient = {
   scan: mockScan,
   get: mockGet,
   update: mockUpdate,
   promise: mockPromise,
+  put: mockPut,
 };
 
 // Mock AWS SDK - Note the structure here
@@ -219,14 +222,16 @@ describe("GrantService", () => {
       };
 
       mockUpdate.mockReturnValue({
-        promise: vi.fn().mockResolvedValue({ Attributes: updatedAttributes })
+        promise: vi.fn().mockResolvedValue({ Attributes: updatedAttributes }),
       });
 
       const data = await grantService.updateGrant(mockUpdatedGrant);
 
-      expect(data).toEqual(JSON.stringify({
-        Attributes: updatedAttributes
-      }));
+      expect(data).toEqual(
+        JSON.stringify({
+          Attributes: updatedAttributes,
+        })
+      );
       expect(mockGrants[0]).toEqual(mockGrants[0]);
     });
 
@@ -250,10 +255,69 @@ describe("GrantService", () => {
       };
 
       mockUpdate.mockRejectedValue({
-        promise: vi.fn().mockRejectedValue(new Error())
+        promise: vi.fn().mockRejectedValue(new Error()),
       });
 
-      await expect(grantService.updateGrant(mockUpdatedGrant)).rejects.toThrow(new Error("Failed to update Grant 90"))
-    })
+      await expect(grantService.updateGrant(mockUpdatedGrant)).rejects.toThrow(
+        new Error("Failed to update Grant 90")
+      );
+    });
   });
+
+  describe("addGrant()", () => {
+    it("should successfully add a grant and return the new grant id", async () => {
+      const mockCreateGrantDto: CreateGrantDto = {
+        organization: "New test organization",
+        description: "This is a new organization that does organizational things",
+        grantmaker_poc: ["newtestorg@test.com"],
+        application_deadline: "2026-02-14",
+        report_deadline: "2026-11-05",
+        notification_date: "2026-10-07",
+        timeline: 200,
+        estimated_completion_time: 200,
+        does_bcan_qualify: true,
+        status: Status.Potential,
+        amount: 35000,
+        attachments: [],
+      }
+
+      mockPut.mockReturnValue({
+        promise: vi.fn().mockResolvedValue(Date.now())
+      });
+
+      const data = await grantService.addGrant(mockCreateGrantDto);
+
+      expect(data).toEqual(Date.now());
+      expect(mockDocumentClient.put).toHaveBeenCalledWith({
+        TableName: expect.any(String),
+        Item: {
+          grantId: expect.any(Number),
+          ...mockCreateGrantDto
+        }
+      })
+    })
+
+    it("should throw an error if the database put operation fails", async () => {
+      const mockCreateGrantDto = {
+        organization: "New Org",
+        description: "New Desc",
+        grantmaker_poc: ["new@test.com"],
+        application_deadline: "2025-04-01",
+        notification_date: "2025-04-10",
+        report_deadline: "2025-05-01",
+        timeline: 3,
+        estimated_completion_time: 200,
+        does_bcan_qualify: true,
+        status: Status.Active,
+        amount: 1500,
+        attachments: [],
+      };
+
+      mockPut.mockRejectedValue(new Error("DB Error"));
+
+      await expect(grantService.addGrant(mockCreateGrantDto)).rejects.toThrow(
+        "Failed to upload new grant from New Org"
+      );
+    })
+  })
 });

--- a/backend/src/grant/grant.service.ts
+++ b/backend/src/grant/grant.service.ts
@@ -51,7 +51,7 @@ export class GrantService {
         }
     }
 
-    // Method to archive grants takes in array 
+    // Method to unarchive grants takes in array 
     async unarchiveGrants(grantIds :number[]) : Promise<number[]> {
         let successfulUpdates: number[] = [];
         for (const grantId of grantIds) {
@@ -70,7 +70,7 @@ export class GrantService {
                 console.log(res)
 
                 if (res.Attributes && res.Attributes.isArchived === false) {
-                    console.log(`Grant ${grantId} successfully archived.`);
+                    console.log(`Grant ${grantId} successfully un-archived.`);
                     successfulUpdates.push(grantId);
                 } else {
                     console.log(`Grant ${grantId} update failed or no change in status.`);

--- a/backend/src/grant/grant.service.ts
+++ b/backend/src/grant/grant.service.ts
@@ -1,4 +1,4 @@
-import { Injectable,Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import AWS from 'aws-sdk';
 import { Grant } from '../../../middle-layer/types/Grant';
 import { CreateGrantDto } from './dto/create-grant.dto';
@@ -39,11 +39,13 @@ export class GrantService {
             const data = await this.dynamoDb.get(params).promise();
 
             if (!data.Item) {
-                throw new Error('No grant with id ' + grantId + ' found.');
+                throw new NotFoundException('No grant with id ' + grantId + ' found.');
             }
 
             return data.Item as Grant;
         } catch (error) {
+            if (error instanceof NotFoundException) throw error;
+            
             console.log(error)
             throw new Error('Failed to retrieve grant.');
         }


### PR DESCRIPTION
### ℹ️ Issue
Closes #134

### 📝 Description
I added unit tests for each method in the grant service, mocking the parameters supplied to the DynamoDB calls, as well as the responses returned by the database.

### ✔️ Verification

Tests in `grant.service.spec.ts`
<img width="953" height="173" alt="Screenshot 2025-09-20 at 3 21 37 PM" src="https://github.com/user-attachments/assets/62c2b924-c7e8-4230-ac53-696cc58d1d7e" />

### 🏕️ (Optional) Future Work / Notes
It might help with descriptiveness to throw specific types of errors in the grant service instead of always throwing a general `Error` object. I ended up changing one of the errors in `getGrantById()` to a `NotFoundException`.