### PR TITLE
Implement auto logout

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -97,18 +97,21 @@ export class AuthController {
     @Res({ passthrough: true }) response: Response,
     @Req() req: any
   ): Promise<{ message: string }> {
-    // Try to invalidate Cognito session if access token is available
-    try {
-      const authHeader = req.headers['authorization'] || req.headers['Authorization'];
-      if (authHeader) {
-        const token = authHeader.startsWith('Bearer ') 
-          ? authHeader.substring(7) 
-          : authHeader;
-        await this.authService.logout(token);
-      }
-    } catch (error) {
-      // Log error but continue - we'll clear cookies anyway
-      console.error('Error invalidating Cognito session:', error);
+    const cookieToken = req.cookies?.access_token;  
+    let token: string | undefined = cookieToken;  
+
+    if (!token) {  
+      const authHeader = req.headers['authorization'] || req.headers['Authorization'];  
+      if (authHeader && typeof authHeader === 'string') {  
+        token = authHeader.startsWith('Bearer ')  
+          ? authHeader.substring(7)  
+          : authHeader;  
+      }  
+    }  
+
+    // Logout user in Cognito
+    if (token) {  
+      await this.authService.logout(token);
     }
 
     // Clear all cookies

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -82,6 +82,44 @@ export class AuthController {
   }
   
   /**
+   * Logs out a user by clearing authentication cookies
+   */
+  @Post('logout')
+  @ApiResponse({
+    status: 200,
+    description: "User logged out successfully"
+  })
+  @ApiResponse({
+    status: 500,
+    description: "Internal Server Error"
+  })
+  async logout(
+    @Res({ passthrough: true }) response: Response,
+    @Req() req: any
+  ): Promise<{ message: string }> {
+    // Try to invalidate Cognito session if access token is available
+    try {
+      const authHeader = req.headers['authorization'] || req.headers['Authorization'];
+      if (authHeader) {
+        const token = authHeader.startsWith('Bearer ') 
+          ? authHeader.substring(7) 
+          : authHeader;
+        await this.authService.logout(token);
+      }
+    } catch (error) {
+      // Log error but continue - we'll clear cookies anyway
+      console.error('Error invalidating Cognito session:', error);
+    }
+
+    // Clear all cookies
+    response.clearCookie('access_token', { path: '/' });
+    response.clearCookie('refresh_token', { path: '/auth/refresh' });
+    response.clearCookie('id_token', { path: '/' });
+    
+    return { message: 'Logged out successfully' };
+  }
+
+  /**
    * Logs in a user
    */
   @Post('login')

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -291,6 +291,23 @@ export class AuthService {
     return emailRegex.test(email);
   }
 
+  // purpose statement: logs out a user by invalidating their Cognito session
+  async logout(accessToken: string): Promise<void> {
+    try {
+      await this.cognito
+        .globalSignOut({
+          AccessToken: accessToken,
+        })
+        .promise();
+
+      this.logger.log('User signed out successfully from Cognito');
+    } catch (error) {
+      this.logger.error('Error during Cognito sign out:', error);
+      // Don't throw error since we still clear cookies in controller
+      // This handles cases where token is already expired
+    }
+  }
+
   // purpose statement: logs in an user via cognito and retrieves user data from dynamodb
   // use case: employee is trying to access the app, needs to have an account already
 

--- a/frontend/src/context/auth/authContext.tsx
+++ b/frontend/src/context/auth/authContext.tsx
@@ -1,4 +1,4 @@
-import { useContext, createContext, ReactNode } from 'react';
+import { useContext, createContext, ReactNode, useEffect, useRef } from 'react';
 import { getAppStore } from '../../external/bcanSatchel/store';
 import { setAuthState, logoutUser } from '../../external/bcanSatchel/actions';
 import { observer } from 'mobx-react-lite';
@@ -31,6 +31,11 @@ export const useAuthContext = () => {
 
 export const AuthProvider = observer(({ children }: { children: ReactNode }) => {
   const store = getAppStore();
+  const logoutTimerRef = useRef<NodeJS.Timeout | null>(null);
+  
+  // Auto-logout timeout duration (in milliseconds)
+  // 8 hours = 8 * 60 * 60 * 1000
+  const SESSION_TIMEOUT = 8 * 60 * 60 * 1000;
 
   /** Attempt to log in the user */
   const login = async (email: string, password: string): Promise<boolean> => {
@@ -100,7 +105,36 @@ export const AuthProvider = observer(({ children }: { children: ReactNode }) => 
   const logout = () => {
     api('/auth/logout', { method: 'POST' });
     logoutUser();
+    // Clear the logout timer when user manually logs out
+    if (logoutTimerRef.current) {
+      clearTimeout(logoutTimerRef.current);
+      logoutTimerRef.current = null;
+    }
   };
+
+  /** Start the auto-logout timer (8 hours from now) */
+  useEffect(() => {
+    if (!store.isAuthenticated) {
+      // Clear timer if user is not authenticated
+      if (logoutTimerRef.current) {
+        clearTimeout(logoutTimerRef.current);
+        logoutTimerRef.current = null;
+      }
+      return;
+    }
+
+    // Start the 8-hour timer when user logs in
+    logoutTimerRef.current = setTimeout(() => {
+      logout();
+    }, SESSION_TIMEOUT);
+
+    // Cleanup: clear timer on unmount or logout
+    return () => {
+      if (logoutTimerRef.current) {
+        clearTimeout(logoutTimerRef.current);
+      }
+    };
+  }, [store.isAuthenticated]);
 
   /** Restore user session on refresh */
   // useEffect(() => {

--- a/frontend/src/context/auth/authContext.tsx
+++ b/frontend/src/context/auth/authContext.tsx
@@ -31,8 +31,7 @@ export const useAuthContext = () => {
 
 export const AuthProvider = observer(({ children }: { children: ReactNode }) => {
   const store = getAppStore();
-  const logoutTimerRef = useRef<NodeJS.Timeout | null>(null);
-  
+  const logoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Auto-logout timeout duration (in milliseconds)
   // 8 hours = 8 * 60 * 60 * 1000
   const SESSION_TIMEOUT = 8 * 60 * 60 * 1000;


### PR DESCRIPTION
### ℹ️ Issue

Closes #322 

### 📝 Description

Changes made to the code:
1. Added useEffect in `authContext.tsx` to start/clear the 8 hour timer on login/logout (respectively)
2. Added logout method in backend controller and service to clear cookies
3. Added testing for new backend route

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.
- I ran the backend with a 1 minute timer to test, and it auto logged me out after a minute!


### Test Changes
If your new feature required some test to be changed or added to fit the new functionality or changes please document these changes here.

N/A

### 🏕️ (Optional) Future Work / Notes

Noticed that `/auth/refresh` endpoint does not exist for the refresh token; will need to be made in the future.