### PR TITLE
334 dev   implement refresh token route

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -125,6 +125,8 @@ export class AuthController {
     });
   }
 
+  response.clearCookie('refresh_token', { path: '/auth/refresh' });
+
   if (result.refreshToken) {
     console.log("refresh token set")
     response.cookie('refresh_token', result.refreshToken, {
@@ -187,12 +189,13 @@ export class AuthController {
     );
 
     const email = idTokenPayload.email;
+    const cognitoUsername = idTokenPayload['cognito:username'];
 
-    if (!email) {
+    if (!email || !cognitoUsername) {
       throw new UnauthorizedException('Could not extract user identity from token');
     }
 
-    const { accessToken, idToken: newIdToken } = await this.authService.refreshTokens(refreshToken, email);
+    const { accessToken, idToken: newIdToken } = await this.authService.refreshTokens(refreshToken, cognitoUsername);
 
     response.cookie('access_token', accessToken, {
       httpOnly: true,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -652,7 +652,7 @@ export class AuthService {
   // purpose statement: uses a valid refresh token to get a new access & id token
   // use case: a logged in user's access token has expired and needs to be refreshed
   // without re-athenticating
-  async refreshTokens(refreshToken: string, email: string): Promise<{
+  async refreshTokens(refreshToken: string, cognitoUsername: string): Promise<{
   accessToken: string;
   idToken: string;
 }> {
@@ -669,14 +669,14 @@ export class AuthService {
     throw new UnauthorizedException('No refresh token provided');
   }
 
-  if (!email) {
+  if (!cognitoUsername) {
     this.logger.error('Token refresh failed: could not determine user identity');
     throw new UnauthorizedException('Could not determine user identity');
   }
 
-  this.logger.log(`Starting token refresh for user: ${email}`);
+  this.logger.log(`Starting token refresh for user: ${cognitoUsername}`);
 
-  const hatch = this.computeHatch(email, clientId, clientSecret);
+  const hatch = this.computeHatch(cognitoUsername, clientId, clientSecret);
 
   const params = {
     AuthFlow: 'REFRESH_TOKEN_AUTH',
@@ -700,7 +700,7 @@ export class AuthService {
       throw new InternalServerErrorException('Failed to refresh tokens');
     }
 
-    this.logger.log(`Tokens refreshed successfully for user: ${email}`);
+    this.logger.log(`Tokens refreshed successfully for user: ${cognitoUsername}`);
 
     return {
       accessToken: response.AuthenticationResult.AccessToken,
@@ -710,11 +710,11 @@ export class AuthService {
     const cognitoError = error as AwsCognitoError;
 
     if (cognitoError.code === 'NotAuthorizedException') {
-      this.logger.error(`Token refresh failed for ${email}: refresh token is expired or invalid`);
+      this.logger.error(`Token refresh failed for ${cognitoUsername}: refresh token is expired or invalid`);
       throw new UnauthorizedException('Refresh token is expired or invalid');
     }
 
-    this.logger.error(`Token refresh for ${email}`, (error as Error).stack);
+    this.logger.error(`Token refresh for ${cognitoUsername}`, (error as Error).stack);
     throw new InternalServerErrorException('Failed to refresh tokens');
   }
 }


### PR DESCRIPTION
### ℹ️ Issue

Closes #334 

### 📝 Description

The ticket adds a route to the backend that allows users to silently refresh their access and id tokens via the refresh token. This is important for keeping users logged in past the 1h access token expiry window.

Briefly list the changes made to the code:
1. Added post /auth/refresh route that reads the refresh token and id_token cookies from the request.
2. Added refresh token method that calls Cognito's REFRESH_TOKEN_AUTH flow and returns a new access token and id token.
3. Added clearCookie call on the login route to prevent stale refresh token issues on re-login

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Manually tested via devtools browser console using the fetch API. Confirmed success messages in the terminal & console. Also deleted the refresh_token, id_token, or both in devtools application tab and re-ran the fetch to confirm 401.

Provide screenshots of any new components, styling changes, or pages. 


### Test Changes
If your new feature required some test to be changed or added to fit the new functionality or changes please document these changes here.

n/a

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!

Cognito's REFRESH_TOKEN_AUTH flow requires the SECRET_HASH to be computed using cognito:username (the internal UUID) rather than the user's email. This is different from the login flow which accepts email as the username credential.