### PR TITLE
372 dev   upload cash starting amount personal benefits increase and personal salary increase

### DIFF
--- a/backend/src/default-values/default-values.controller.ts
+++ b/backend/src/default-values/default-values.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Patch, Logger, UseGuards} from '@nestjs/common';
+import { Body, Controller, Get, Logger, UseGuards, Put} from '@nestjs/common';
 import { ApiBody, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { DefaultValuesService } from './default-values.service';
 import {
@@ -45,7 +45,7 @@ export class DefaultValuesController {
      * @param body - UpdateDefaultValueBody containing the key of the default value to update and the new value
      * @returns new DefaultValuesResponse with the updated default values
      */
-    @Patch()
+    @Put()
     @UseGuards(VerifyAdminRoleGuard)
     @ApiBearerAuth()
     @ApiBody({ schema: {
@@ -74,9 +74,9 @@ export class DefaultValuesController {
     async updateDefaultValue(
         @Body() body: UpdateDefaultValueBody,
     ): Promise<DefaultValuesResponse> {
-        this.logger.log(`PATCH /default-values - Updating default value for key: ${body.key}`);
+        this.logger.log(`PUT /default-values - Updating default value for key: ${body.key}`);
         const updatedValues = await this.defaultValuesService.updateDefaultValue(body.key, body.value);
-        this.logger.log(`PATCH /default-values - Successfully updated default value for key: ${body.key}`);
+        this.logger.log(`PUT /default-values - Successfully updated default value for key: ${body.key}`);
         return updatedValues;
     }
 }

--- a/frontend/src/external/bcanSatchel/actions.ts
+++ b/frontend/src/external/bcanSatchel/actions.ts
@@ -5,6 +5,7 @@ import { Status } from '../../../../middle-layer/types/Status'
 import { Notification } from '../../../../middle-layer/types/Notification';
 import { CashflowCost } from '../../../../middle-layer/types/CashflowCost';
 import { CashflowRevenue } from '../../../../middle-layer/types/CashflowRevenue';
+import { CashflowSettings } from '../../../../middle-layer/types/CashflowSettings';
 
 /**
  * Set whether the user is authenticated, update the user object,
@@ -58,6 +59,10 @@ export const fetchCashflowRevenues = action("fetchCashflowRevenues", (revenues: 
 export const fetchCashflowCosts = action("fetchCashflowCosts", (costs: CashflowCost[]) => ({
   costs,
 }));
+
+export const setCashflowSettings = action("setCashflowSettings", 
+  (cashflowSettings: CashflowSettings) => ({ cashflowSettings })
+);
 
 export const updateFilter = action("updateFilter", (status: Status | null) => ({
   status,

--- a/frontend/src/external/bcanSatchel/mutators.ts
+++ b/frontend/src/external/bcanSatchel/mutators.ts
@@ -22,6 +22,7 @@ import {
   removeProfilePic,
   fetchCashflowRevenues,
   fetchCashflowCosts,
+  setCashflowSettings
 } from "./actions";
 import { getAppStore, persistToSessionStorage } from "./store";
 
@@ -236,4 +237,13 @@ mutator(removeProfilePic, () => {
   }
 
   persistToSessionStorage();
+});
+
+/**
+ * setCashflowSettings mutator
+ */
+
+mutator(setCashflowSettings, (actionMessage) => {
+  const store = getAppStore();
+  store.cashflowSettings = actionMessage.cashflowSettings;
 });

--- a/frontend/src/external/bcanSatchel/store.ts
+++ b/frontend/src/external/bcanSatchel/store.ts
@@ -5,6 +5,7 @@ import { Status } from '../../../../middle-layer/types/Status'
 import { Notification } from '../../../../middle-layer/types/Notification'
 import { CashflowRevenue } from '../../../../middle-layer/types/CashflowRevenue'
 import { CashflowCost } from '../../../../middle-layer/types/CashflowCost'
+import { CashflowSettings } from '../../../../middle-layer/types/CashflowSettings'
 
 export interface AppState {
   isAuthenticated: boolean;
@@ -29,6 +30,7 @@ export interface AppState {
   userQuery: string;
   revenueSources: CashflowRevenue[];
   costSources: CashflowCost[];
+  cashflowSettings: CashflowSettings | null;
 }
 
 // Define initial state
@@ -54,6 +56,7 @@ const initialState: AppState = {
   userQuery: '',
   revenueSources: [],
   costSources: [],
+  cashflowSettings: null,
 };
 
 /**

--- a/frontend/src/main-page/cash-flow/components/CashAnnualSettings.tsx
+++ b/frontend/src/main-page/cash-flow/components/CashAnnualSettings.tsx
@@ -1,6 +1,27 @@
 import InputField from "../../../components/InputField";
+import { observer } from "mobx-react-lite";
+import { getAppStore } from "../../../external/bcanSatchel/store";
+import { setCashflowSettings } from "../../../external/bcanSatchel/actions";
 
-export default function CashAnnualSettings() {
+const CashAnnualSettings = observer(() => {
+
+  const { cashflowSettings } = getAppStore();
+
+  const handleSalaryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!cashflowSettings) return;
+    setCashflowSettings({
+      ...cashflowSettings,
+      salaryIncrease: e.target.valueAsNumber,
+    });
+  };
+
+  const handleBenefitsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!cashflowSettings) return;
+    setCashflowSettings({
+      ...cashflowSettings,
+      benefitsIncrease: e.target.valueAsNumber,
+    });
+  };
 
   return (
     <div className="chart-container col-span-2 h-full">
@@ -12,16 +33,20 @@ export default function CashAnnualSettings() {
           type="number"
           id="salary_increase"
           label="Personnel Salary Increase (%)"
-          value={"3.5"}
+          value={cashflowSettings?.salaryIncrease ?? 0}
+          onChange={handleSalaryChange}
           className=""
         />
         <InputField
           type="number"
           id="benefits_increase"
           label="Personnel Benefits Increase (%)"
-          value={"4.0"}
+          value={cashflowSettings?.benefitsIncrease ?? 0}
+          onChange={handleBenefitsChange}
         />
       </div>
     </div>
   );
-}
+});
+
+export default CashAnnualSettings;

--- a/frontend/src/main-page/cash-flow/components/CashPosition.tsx
+++ b/frontend/src/main-page/cash-flow/components/CashPosition.tsx
@@ -1,6 +1,20 @@
 import InputField from "../../../components/InputField";
+import { observer } from "mobx-react-lite";
+import { getAppStore } from "../../../external/bcanSatchel/store";
+import { setCashflowSettings } from "../../../external/bcanSatchel/actions";
 
-export default function CashPosition() {
+const CashPosition = observer(() => {
+
+  const { cashflowSettings } = getAppStore();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!cashflowSettings) return;
+    setCashflowSettings({
+      ...cashflowSettings,
+      startingCash: e.target.valueAsNumber,
+    });
+  };
+
   return (
     <div className="chart-container col-span-2 h-full">
       <div className="text-lg lg:text-xl mb-2 w-full text-left font-bold">
@@ -10,8 +24,11 @@ export default function CashPosition() {
         type="number"
         id="starting_balance"
         label="Current Cash Balance"
-        value={"25000"}
+        value={cashflowSettings?.startingCash ?? 0}
+        onChange={handleChange}
       />
     </div>
   );
-}
+});
+
+export default CashPosition;

--- a/frontend/src/main-page/cash-flow/processCashflowData.ts
+++ b/frontend/src/main-page/cash-flow/processCashflowData.ts
@@ -1,8 +1,9 @@
 import { useEffect } from "react";
 import { getAppStore } from "../../external/bcanSatchel/store.ts";
-import { fetchCashflowCosts, fetchCashflowRevenues } from "../../external/bcanSatchel/actions.ts";
+import { fetchCashflowCosts, fetchCashflowRevenues, setCashflowSettings } from "../../external/bcanSatchel/actions.ts";
 import {CashflowRevenue} from "../../../../middle-layer/types/CashflowRevenue.ts";
 import {CashflowCost} from "../../../../middle-layer/types/CashflowCost.ts";
+import {CashflowSettings} from "../../../../middle-layer/types/CashflowSettings.ts";
 import { api } from "../../api.ts";
 
 // This has not been tested yet but the basic structure when implemented should be the same
@@ -37,13 +38,27 @@ export const fetchRevenues = async () => {
   }
 };
 
+export const fetchCashflowSettings = async () => {
+  try {
+    const response = await api("/default-values");
+    if (!response.ok) {
+      throw new Error(`HTTP Error, Status: ${response.status}`);
+    }
+    const settings: CashflowSettings = await response.json();
+    setCashflowSettings(settings);
+  } catch (error) {
+    console.error("Error fetching cashflow settings:", error);
+  }
+};
+
 
 // could contain callbacks for sorting and filtering line items
 // stores state for list of costs/revenues
 export const ProcessCashflowData = () => {
     const {
         costSources,
-        revenueSources
+        revenueSources,
+        cashflowSettings
   } = getAppStore();
 
   // fetch costs on mount if empty
@@ -56,5 +71,10 @@ export const ProcessCashflowData = () => {
     if (revenueSources.length === 0) fetchRevenues();
   }, [revenueSources.length]);
 
-  return { costs: costSources, revenues: revenueSources };
+  // fetch settings on mount if null
+  useEffect(() => {
+    if (!cashflowSettings) fetchCashflowSettings();
+  }, [cashflowSettings]);
+
+  return { costs: costSources, revenues: revenueSources, cashflowSettings };
 };

--- a/frontend/src/main-page/cash-flow/processCashflowDataEditSave.ts
+++ b/frontend/src/main-page/cash-flow/processCashflowDataEditSave.ts
@@ -1,7 +1,8 @@
 import {CashflowRevenue} from "../../../../middle-layer/types/CashflowRevenue.ts";
 import {CashflowCost} from "../../../../middle-layer/types/CashflowCost.ts";
+import { CashflowSettings } from "../../../../middle-layer/types/CashflowSettings.ts";
 import { api } from "../../api.ts";
-import { fetchCosts, fetchRevenues } from "./processCashflowData.ts";
+import { fetchCosts, fetchRevenues, fetchCashflowSettings } from "./processCashflowData.ts";
 
 // This has not been tested yet but the basic structure when implemented should be the same
 // Mirrored format for processGrantDataEditSave.ts
@@ -212,3 +213,34 @@ export const deleteCost = async (costId: any) => {
           console.error("Full error:", err);
         }
       };
+
+export const saveCashflowSettings = async (settings: CashflowSettings) => {
+  try {
+    const updates = [
+      { key: "startingCash", value: settings.startingCash },
+      { key: "salaryIncrease", value: settings.salaryIncrease },
+      { key: "benefitsIncrease", value: settings.benefitsIncrease },
+    ];
+
+    for (const update of updates) {
+      const response = await api("/default-values", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(update),
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || `Failed to update ${update.key}`);
+      }
+    }
+
+    await fetchCashflowSettings();
+    return { success: true };
+  } catch (error) {
+    console.error("Error saving cashflow settings:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Server error. Please try again.",
+    };
+  }
+};

--- a/frontend/src/main-page/cash-flow/processCashflowDataEditSave.ts
+++ b/frontend/src/main-page/cash-flow/processCashflowDataEditSave.ts
@@ -224,7 +224,7 @@ export const saveCashflowSettings = async (settings: CashflowSettings) => {
 
     for (const update of updates) {
       const response = await api("/default-values", {
-        method: "PATCH",
+        method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(update),
       });

--- a/frontend/src/main-page/navbar/NavBar.tsx
+++ b/frontend/src/main-page/navbar/NavBar.tsx
@@ -11,6 +11,7 @@ import { UserStatus } from "../../../../middle-layer/types/UserStatus";
 import NavTab, { NavTabProps } from "./NavTab.tsx";
 import { faChartLine, faMoneyBill, faClipboardCheck } from "@fortawesome/free-solid-svg-icons";
 import { NavBarBranding } from "../../translations/general.ts";
+import { saveCashflowSettings } from "../cash-flow/processCashflowDataEditSave";
 
 const tabs: NavTabProps[] = [
   { name: "Dashboard", linkTo: "/main/dashboard", icon: faChartLine },
@@ -26,7 +27,11 @@ const NavBar: React.FC = observer(() => {
   const user = getAppStore().user;
   const isAdmin = user?.position === UserStatus.Admin;
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    const { cashflowSettings } = getAppStore();
+    if (cashflowSettings) {
+    await saveCashflowSettings(cashflowSettings);
+  }
     logoutUser();
     clearAllFilters();
     navigate("/login");

--- a/middle-layer/types/CashflowSettings.ts
+++ b/middle-layer/types/CashflowSettings.ts
@@ -1,0 +1,5 @@
+export interface CashflowSettings {
+  startingCash: number;
+  salaryIncrease: number;
+  benefitsIncrease: number;
+}


### PR DESCRIPTION
### ℹ️ Issue

Closes #372 

### 📝 Description

Made cash starting amount, personnel benefits increase, and personnel salary increase functional. The fields are now editable, connected to store, and saved to backend on logout so that changes will persist between sessions. 

Briefly list the changes made to the code:
1. Added CashflowSettings type to middle layer
2. Added cashflowSettings field to store, actions, and mutators
3. Added fetchCashflowSettings to fetch settings from the backend endpoint
4. Added saveCashflowSettings to save all three settings to backend on logout
5. Updated CashPosition and CashAnnualSettings to be editable and connected to store
6. Updated NavBar logout handler to save cashflow settings before clearing the store
7. Updated default-values controller from patch to put to fix CORS blocking issue

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Tested locally. Confirmed values change after logout in DynamoDB table.

Provide screenshots of any new components, styling changes, or pages. 


### Test Changes
If your new feature required some test to be changed or added to fit the new functionality or changes please document these changes here.


### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!