### PR TITLE
update delete grant so it deletes notifs too

### DIFF
--- a/backend/src/grant/__test__/grant.service.spec.ts
+++ b/backend/src/grant/__test__/grant.service.spec.ts
@@ -171,14 +171,15 @@ describe("GrantService", () => {
     grantService = Object.assign(module.get<GrantService>(GrantService), {
       notificationService: { 
         createNotification: vi.fn(), 
-        updateNotification: vi.fn() 
+        updateNotification: vi.fn(),
+        getNotificationByUserEmail: vi.fn().mockResolvedValue([]),
+        deleteNotification: vi.fn().mockResolvedValue('deleted') 
       }
     });
 
     
     
     controller = module.get<GrantController>(GrantController);
-    grantService = module.get<GrantService>(GrantService);
     
   });
 
@@ -585,8 +586,16 @@ describe("GrantService", () => {
   // Tests for deleteGrantById method
 describe('deleteGrantById', () => {
   it('should call DynamoDB delete with the correct params and return success message', async () => {
+    mockGet.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Item: mockGrants[0] })
+    });
+
     mockDelete.mockReturnValue({
       promise: vi.fn().mockResolvedValue({})
+    });
+
+    mockQuery.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Items: [] })
     });
 
     const result = await grantService.deleteGrantById(123);
@@ -610,6 +619,14 @@ describe('deleteGrantById', () => {
     const conditionalError = new Error('Conditional check failed');
     (conditionalError as any).code = 'ConditionalCheckFailedException';
 
+    mockGet.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Item: mockGrants[0] })
+    });
+
+    mockQuery.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Items: [] })
+    });
+
     mockDelete.mockReturnValue({
       promise: vi.fn().mockRejectedValue(conditionalError)
     });
@@ -629,6 +646,14 @@ describe('deleteGrantById', () => {
     const conditionalError = new Error('Conditional check failed');
     (conditionalError as any).code = 'ConditionalCheckFailedException';
 
+    mockGet.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Item: mockGrants[0] })
+    });
+
+    mockQuery.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Items: [] })
+    });
+
     mockDelete.mockReturnValue({
       promise: vi.fn().mockRejectedValue(conditionalError)
     });
@@ -643,6 +668,14 @@ describe('deleteGrantById', () => {
     const awsError = new Error('AWS DynamoDB error');
     (awsError as any).code = 'ThrottlingException';
 
+    mockGet.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Item: mockGrants[0] })
+    });
+
+    mockQuery.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Items: [] })
+    });
+
     mockDelete.mockReturnValue({
       promise: vi.fn().mockRejectedValue(awsError)
     });
@@ -654,6 +687,15 @@ describe('deleteGrantById', () => {
   });
 
   it('should throw InternalServerErrorException for generic DynamoDB errors', async () => {
+
+    mockGet.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Item: mockGrants[0] })
+    });
+
+    mockQuery.mockReturnValue({
+      promise: vi.fn().mockResolvedValue({ Items: [] })
+    });
+
     mockDelete.mockReturnValue({
       promise: vi.fn().mockRejectedValue(new Error('Some other DynamoDB error'))
     });
@@ -684,11 +726,15 @@ describe('Notification helpers', () => {
       const result = (grantServiceWithMockNotif as any).getNotificationTimes(deadline);
 
       expect(result).toHaveLength(3);
-      result.forEach((date: any) => expect(date).toMatch(/^\d{4}-\d{2}-\d{2}T/));
+      result.forEach(({ alertTime, days }: { alertTime: string, days: number }) => {
+        expect(alertTime).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect([14, 7, 3]).toContain(days);
+      });
 
-      const parsed = result.map((r: string | number | Date) => new Date(r));
       const main = new Date(deadline);
-      const diffs = parsed.map((d: string | number) => Math.round((+main - +d) / (1000 * 60 * 60 * 24)));
+      const diffs = result.map(({ alertTime }: { alertTime: string }) =>
+      Math.round((+main - +new Date(alertTime)) / (1000 * 60 * 60 * 24))
+      );
 
       expect(diffs).toEqual([14, 7, 3]);
     });

--- a/backend/src/grant/grant.service.ts
+++ b/backend/src/grant/grant.service.ts
@@ -164,7 +164,7 @@ export class GrantService {
         const params = {
             TableName: process.env.DYNAMODB_GRANT_TABLE_NAME || 'TABLE_FAILURE',
             Key: {
-                grantId: grantId,
+                grantId: Number(grantId),
             },
         };
 
@@ -457,6 +457,7 @@ export class GrantService {
     }
 
     try {
+        await this.deleteGrantNotifications(grantId);
         this.logger.debug(`Executing DynamoDB delete for grant ${grantId}`);
         await this.dynamoDb.delete(params).promise();
         this.logger.log(`Successfully deleted grant ${grantId} from database`);
@@ -483,14 +484,27 @@ export class GrantService {
     }
   }
 
+  // Deletes notifications associated with a particular grant
+  private async deleteGrantNotifications(grantId: number): Promise<void> {
+    this.logger.log(`Deleting notifications for grant ${grantId}`);
+    const grant = await this.getGrantById(grantId);
+    const email = grant.bcan_poc.POC_email;
+    const notifications = await this.notificationService.getNotificationByUserEmail(email);
+    const grantNotifications = notifications.filter(n => n.notificationId.startsWith(`${grantId}-`));
+    for (const notification of grantNotifications) {
+        await this.notificationService.deleteNotification(notification.notificationId);
+    }
+    this.logger.log(`Successfully deleted notifications for grant ${grantId}`);
+}
+
   // Calculates notification times for a deadline (14, 7, and 3 days before)
-  private getNotificationTimes(deadlineISO: string): string[] {
+  private getNotificationTimes(deadlineISO: string): { alertTime: string, days: number }[] {
     const deadline = new Date(deadlineISO);
     const daysBefore = [14, 7, 3];
     return daysBefore.map(days => {
       const d = new Date(deadline);
       d.setDate(deadline.getDate() - days);
-      return d.toISOString();
+      return { alertTime: d.toISOString(), days };
     });
   }
 
@@ -507,13 +521,13 @@ export class GrantService {
         `Creating application deadline notifications for grant ${grantId} with deadline ${application_deadline}`,
       );
       const alertTimes = this.getNotificationTimes(application_deadline);
-      for (const alertTime of alertTimes) {
+      for (const { alertTime, days } of alertTimes) {
         this.logger.debug(
           `Creating application notification for grant ${grantId} at alertTime ${alertTime}`,
         );
-        const message = `Application due in ${this.daysUntil(alertTime, application_deadline)} days for ${organization}`;
+        const message = `Application due in ${days} days for ${organization}`;
         const notification: Notification = {
-          notificationId: `${grantId}-app`,
+          notificationId: `${grantId}-app-${days}`,
           userEmail: email,
           message,
           alertTime: alertTime as TDateISO,
@@ -532,15 +546,15 @@ export class GrantService {
       this.logger.debug(
         `Creating report deadline notifications for grant ${grantId} with ${report_deadlines.length} report_deadlines`,
       );
-      for (const reportDeadline of report_deadlines) {
+      for (const [i, reportDeadline] of report_deadlines.entries()) {
         const alertTimes = this.getNotificationTimes(reportDeadline);
-        for (const alertTime of alertTimes) {
+        for (const {alertTime, days} of alertTimes) {
           this.logger.debug(
             `Creating report notification for grant ${grantId} at alertTime ${alertTime} (report deadline ${reportDeadline})`,
           );
-          const message = `Report due in ${this.daysUntil(alertTime, reportDeadline)} days for ${organization}`;
+          const message = `Report due in ${days} days for ${organization}`;
           const notification: Notification = {
-            notificationId: `${grantId}-report`,
+            notificationId: `${grantId}-report-${i}-${days}`,
             userEmail: email,
             message,
             alertTime: alertTime as TDateISO,
@@ -573,9 +587,9 @@ export class GrantService {
         `Updating application deadline notifications for grant ${grantId} with deadline ${application_deadline}`,
       );
       const alertTimes = this.getNotificationTimes(application_deadline);
-      for (const alertTime of alertTimes) {
-        const notificationId = `${grantId}-app`;
-        const message = `Application due in ${this.daysUntil(alertTime, application_deadline)} days for ${organization}`;
+      for (const { alertTime, days } of alertTimes) {
+        const notificationId = `${grantId}-app-${days}`;
+        const message = `Application due in ${days} days for ${organization}`;
 
         this.logger.debug(
           `Updating application notification ${notificationId} for grant ${grantId} to alertTime ${alertTime}`,
@@ -596,11 +610,11 @@ export class GrantService {
       this.logger.debug(
         `Updating report deadline notifications for grant ${grantId} with ${report_deadlines.length} report_deadlines`,
       );
-      for (const reportDeadline of report_deadlines) {
+      for (const [i, reportDeadline] of report_deadlines.entries()) {
         const alertTimes = this.getNotificationTimes(reportDeadline);
-        for (const alertTime of alertTimes) {
-          const notificationId = `${grantId}-report`;
-          const message = `Report due in ${this.daysUntil(alertTime, reportDeadline)} days for ${organization}`;
+        for (const { alertTime, days } of alertTimes) {
+          const notificationId = `${grantId}-report-${i}-${days}`;
+          const message = `Report due in ${days} days for ${organization}`;
 
           this.logger.debug(
             `Updating report notification ${notificationId} for grant ${grantId} to alertTime ${alertTime} (report deadline ${reportDeadline})`,


### PR DESCRIPTION
### ℹ️ Issue

Closes #382 

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Makes sure grant notifications are created and deleted when the corresponding grant is created/deleted. It is important because the two entities should be in sync with each other.

Briefly list the changes made to the code:
1. Added deleteGrantNotifications()
2. Called above in deleteGrantById()
3. Fixed a bug that was causing notifications to overwrite each other. Notifications now follow structure ${grantId}-app-${days} and ${grantId}-report-${index}-${days}.
4. uncommented creategrantnotifications call in addgrant

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Created a grant with an application deadline and at least one report deadline in the near past, opened notification dropdown and made sure correct notifications popped up. Deleted the grant. Ensured notifications also correctly deleted from the dropdown and dynamodb table.

Provide screenshots of any new components, styling changes, or pages. 
n/a

### Test Changes
If your new feature required some test to be changed or added to fit the new functionality or changes please document these changes here.


### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
