### PR TITLE
Grant gets shown after it was created

### DIFF
--- a/frontend/src/main-page/grants/GrantPage.tsx
+++ b/frontend/src/main-page/grants/GrantPage.tsx
@@ -4,10 +4,22 @@ import FilterBar from "./filter-bar/FilterBar.tsx";
 import GrantItem from "./grant-view/GrantView.tsx";
 import { observer } from "mobx-react-lite";
 import { ProcessGrantData } from "./filter-bar/processGrantData.ts";
+import {
+  amountRangeFilter,
+  dateRangeFilter,
+  eligibleFilter,
+  filterGrants,
+  searchFilter,
+  statusFilter,
+  userEmailFilter,
+  yearFilterer,
+} from "./filter-bar/grantFilters.ts";
 import GrantCard from "./grant-view/components/GrantCard.tsx";
 import Button from "../../components/Button.tsx";
 import EditGrant from "./edit-grant/EditGrant.tsx";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { clearAllFilters } from "../../external/bcanSatchel/actions.ts";
+import { getAppStore } from "../../external/bcanSatchel/store.ts";
 
 function GrantPage() {
   const [showEditGrant, setShowEditGrant] = useState(false);
@@ -21,11 +33,55 @@ function GrantPage() {
   grants[0] ??
   null;
 
-  // When the first grant in the list changes (sort/filter/initial load), show it
-  const firstGrantId = grants[0]?.grantId ?? null;
+  const handleGrantCreated = (grantId: number) => {
+    setCurId(grantId);
+
+    const {
+      allGrants,
+      filterStatus,
+      startDateFilter,
+      endDateFilter,
+      yearFilter,
+      searchQuery,
+      emailFilter,
+      eligibleOnly,
+      amountMinFilter,
+      amountMaxFilter,
+      user,
+    } = getAppStore();
+
+    const createdGrant = allGrants.find((grant) => grant.grantId === grantId);
+
+    if (createdGrant) {
+      const grantIsVisible =
+        filterGrants([createdGrant], [
+          statusFilter(filterStatus),
+          eligibleFilter(eligibleOnly),
+          dateRangeFilter(startDateFilter, endDateFilter),
+          amountRangeFilter(amountMinFilter, amountMaxFilter),
+          yearFilterer(yearFilter),
+          searchFilter(searchQuery),
+          userEmailFilter(emailFilter, user),
+        ]).length > 0;
+
+      if (!grantIsVisible) {
+        clearAllFilters();
+      }
+    }
+  };
+
+  // Preserve current selection when still visible; otherwise show the first visible grant.
   useEffect(() => {
-    setCurId(grants.length > 0 ? grants[0].grantId : null);
-  }, [firstGrantId]);
+    if (grants.length === 0) {
+      setCurId(null);
+      return;
+    }
+
+    const currentSelectionStillVisible = grants.some((grant) => grant.grantId === curId);
+    if (!currentSelectionStillVisible) {
+      setCurId(grants[0].grantId);
+    }
+  }, [curId, grants]);
 
   return (
     <div className="grant-page w-full items-end flex flex-col h-[86vh]">
@@ -64,6 +120,7 @@ function GrantPage() {
         {showEditGrant && (
           <EditGrant
             grantToEdit={null}
+            onGrantCreated={handleGrantCreated}
             onClose={async () => {
               setShowEditGrant(false);
             }}

--- a/frontend/src/main-page/grants/edit-grant/EditGrant.tsx
+++ b/frontend/src/main-page/grants/edit-grant/EditGrant.tsx
@@ -42,7 +42,8 @@ export interface GrantFormState {
 const EditGrant: React.FC<{
   grantToEdit: Grant | null;
   onClose: () => void;
-}> = observer(({ grantToEdit, onClose }) => {
+  onGrantCreated?: (grantId: number) => void;
+}> = observer(({ grantToEdit, onClose, onGrantCreated }) => {
   // State to track if form was submitted successfully
   const [saving, setSaving] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -144,6 +145,9 @@ const EditGrant: React.FC<{
       : await createNewGrant(grantData);
 
     if (result.success) {
+      if (!grantToEdit && result.grantId != null) {
+        onGrantCreated?.(result.grantId);
+      }
       setSaving(false);
       onClose();
     } else {

--- a/frontend/src/main-page/grants/edit-grant/processGrantDataEditSave.ts
+++ b/frontend/src/main-page/grants/edit-grant/processGrantDataEditSave.ts
@@ -4,8 +4,14 @@ import { api } from "../../../api.ts";
 import { GrantFormState } from "./EditGrant.tsx";
 import { fetchGrants } from "../filter-bar/processGrantData.ts";
 
+export type GrantMutationResult =
+  | { success: true; grantId?: number }
+  | { success: false; error: string };
+
 // save a new grant
-export const createNewGrant = async (newGrant: Grant) => {
+export const createNewGrant = async (
+  newGrant: Grant
+): Promise<GrantMutationResult> => {
   try {
     const response = await api("/grant/new-grant", {
       method: "POST",
@@ -14,8 +20,9 @@ export const createNewGrant = async (newGrant: Grant) => {
     });
 
     if (response.ok) {
+      const createdGrantId = (await response.json()) as number;
       await fetchGrants();
-      return { success: true };
+      return { success: true, grantId: createdGrantId };
     } else {
       const errorData = await response.json();
       throw new Error(errorData.message || "Failed to create grant");
@@ -34,7 +41,9 @@ export const createNewGrant = async (newGrant: Grant) => {
   }
 };
 
-export const saveGrantEdits = async (updatedGrant: Grant) => {
+export const saveGrantEdits = async (
+  updatedGrant: Grant
+): Promise<GrantMutationResult> => {
   try {
     const response = await api("/grant/save", {
       method: "PUT",

--- a/frontend/src/main-page/grants/filter-bar/FilterBar.tsx
+++ b/frontend/src/main-page/grants/filter-bar/FilterBar.tsx
@@ -25,6 +25,7 @@ const FilterBar: React.FC = observer(() => {
     emailFilter,
     eligibleOnly,
     sort,
+    filterStatus,
     startDateFilter,
     endDateFilter,
     amountMinFilter,
@@ -34,7 +35,6 @@ const FilterBar: React.FC = observer(() => {
   const [showDueDateCard, setShowDueDateCard] = useState(false);
   const [showAmountCard, setShowAmountCard] = useState(false);
   const [showStatusDropdown, setShowStatusDropdown] = useState(false);
-  const [selectedStatus, setSelectedStatus] = useState<Status | null>(null);
   const dueDateDropdownRef = useRef<HTMLDivElement | null>(null);
   const amountDropdownRef = useRef<HTMLDivElement | null>(null);
   const statusDropdownRef = useRef<HTMLDivElement | null>(null);
@@ -82,8 +82,7 @@ const FilterBar: React.FC = observer(() => {
   };
 
   const handleStatusSelect = (status: Status) => {
-    const newSelected = selectedStatus === status ? null : status;
-    setSelectedStatus(newSelected);
+    const newSelected = filterStatus === status ? null : status;
     updateFilter(newSelected);
   };
 
@@ -279,11 +278,11 @@ const FilterBar: React.FC = observer(() => {
             logo={showStatusDropdown ? faChevronUp : faChevronDown}
             logoPosition="right"
             className={`bg-white text-sm lg:text-base whitespace-nowrap ${
-              showStatusDropdown || selectedStatus ? activeButtonClass : inactiveButtonClass
+              showStatusDropdown || filterStatus ? activeButtonClass : inactiveButtonClass
             }`}
           />
           {showStatusDropdown && (
-            <StatusDropdown selected={selectedStatus} onSelect={handleStatusSelect} />
+            <StatusDropdown selected={filterStatus} onSelect={handleStatusSelect} />
           )}
         </div>
       </div>


### PR DESCRIPTION
### ℹ️ Issue

Closes #393 

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Briefly list the changes made to the code:
1. Created handleGrantCreated handler on GrantPage.tsx so the grant created will be set to current grant (and filters cleared if necessary)
2. Made it so the createNewGrant function in processGrantDataEditSave.tsx will return the new grant ID to use on the main grant page, since the backend returns it 
3. Fixed bug with the status selector so that if status filter is selected, then cleared through grant creation, it will show on the UI (there was a bug with it not showing the updated clear)

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Provide screenshots of any new components, styling changes, or pages. 

I tested this on my branch with different cases of filters needing to be cleared and not.

### Test Changes
If your new feature required some test to be changed or added to fit the new functionality or changes please document these changes here.

N/A

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!

Not sure if this will be fixed but this card is not super responsive
<img width="1254" height="334" alt="image" src="https://github.com/user-attachments/assets/4d68c151-4309-43c2-a208-f8c83076ab06" />
