### PR TITLE
fixing duplicate revenue data

### DIFF
--- a/backend/src/revenue/__test__/cashflow-revenue.service.spec.ts
+++ b/backend/src/revenue/__test__/cashflow-revenue.service.spec.ts
@@ -4,6 +4,7 @@ import { RevenueService } from '../cashflow-revenue.service';
 import { RevenueType } from '../../../../middle-layer/types/RevenueType';
 import { CashflowRevenue } from '../../../../middle-layer/types/CashflowRevenue';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, vi } from 'vitest';
+import { mock } from 'node:test';
 
 // ─── Mock function declarations ───────────────────────────────────────────────
 const mockGet    = vi.fn();
@@ -330,7 +331,9 @@ describe('RevenueService', () => {
     });
 
     it('should put the new item and delete the old one when name changes', async () => {
-      mockGet.mockReturnValue(resolved({ Item: mockRevenue }));
+      mockGet
+        .mockReturnValueOnce(resolved({ Item: mockRevenue }))
+        .mockReturnValueOnce(resolved({ Item: undefined }));
       mockPut.mockReturnValue(resolved({}));
       mockDelete.mockReturnValue(resolved({}));
 
@@ -354,7 +357,9 @@ describe('RevenueService', () => {
     });
 
     it('should use the route param name as the DynamoDB get key, not the body name', async () => {
-      mockGet.mockReturnValue(resolved({ Item: mockRevenue }));
+      mockGet
+        .mockReturnValueOnce(resolved({ Item: mockRevenue }))
+        .mockReturnValueOnce(resolved({ Item: undefined}));
       mockPut.mockReturnValue(resolved({}));
       await service.updateRevenue('Test Revenue', { ...mockRevenue, name: 'Different Name' });
       expect(mockGet).toHaveBeenCalledWith(expect.objectContaining({
@@ -362,8 +367,38 @@ describe('RevenueService', () => {
       }));
     });
 
+    it('should fail on missing original route-name item before checking rename target or writing', async () => {
+      mockGet.mockReturnValueOnce(resolved({ Item: undefined }));
+
+      await expect(
+        service.updateRevenue('Missing Revenue', { ...mockRevenue, name: 'Revenue Two' })
+      ).rejects.toThrow(/does not exist/i);
+
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      expect(mockGet).toHaveBeenCalledWith(expect.objectContaining({
+        Key: { name: 'Missing Revenue' },
+      }));
+      expect(mockPut).not.toHaveBeenCalled();
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('should reject rename when target name already exists and should not delete the original item', async () => {
+      mockGet
+        .mockReturnValueOnce(resolved({ Item: mockRevenue }))
+        .mockReturnValueOnce(resolved({ Item: { ...mockRevenue, name: 'Revenue Two' } }));
+
+      await expect(
+        service.updateRevenue('Test Revenue', { ...mockRevenue, name: 'Revenue Two' })
+      ).rejects.toThrow(/already exists/i);
+
+      expect(mockPut).not.toHaveBeenCalled();
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
     it('should throw InternalServerErrorException when delete fails after successful put during rename', async () => {
-      mockGet.mockReturnValue(resolved({ Item: mockRevenue }));
+      mockGet
+        .mockReturnValueOnce(resolved({ Item: mockRevenue }))
+        .mockReturnValueOnce(resolved({ Item: undefined }));
       mockPut.mockReturnValue(resolved({}));
       mockDelete.mockReturnValue(rejected(awsError('InternalServerError')));
       await expect(

--- a/backend/src/revenue/cashflow-revenue.service.ts
+++ b/backend/src/revenue/cashflow-revenue.service.ts
@@ -324,6 +324,12 @@ async createRevenue(revenue: CashflowRevenue): Promise<CashflowRevenue> {
   }
 }
 
+  /**
+   * Method to update an existing revenue object
+   * @param name Name of the revenue item to update
+   * @param revenue Updated revenue object
+   * @returns Returns the updated cashflow revenue
+   */
 async updateRevenue(name: string, revenue: CashflowRevenue): Promise<CashflowRevenue> {
   this.validateRevenueObject(revenue);
   this.validateName(name);
@@ -345,6 +351,7 @@ async updateRevenue(name: string, revenue: CashflowRevenue): Promise<CashflowRev
     Key: { name: trimmedRouteName },
   };
 
+  // checks the current/original name from the route (the record you want to edit) exists
   try {
     this.logger.log(`Checking if revenue item with name '${name}' exists`);
     const existing = await this.dynamoDb.get(getParams).promise();
@@ -364,11 +371,43 @@ async updateRevenue(name: string, revenue: CashflowRevenue): Promise<CashflowRev
     throw new InternalServerErrorException('Internal Server Error');
   }
 
+  // When renaming, check if it is a duplicated name
+  if (isRename) {
+    const duplicateCheckParams = {
+      TableName: this.revenueTableName,
+      Key: { name: trimmedBodyName },
+    };
+
+    try {
+      this.logger.log(`Checking if target revenue name '${trimmedBodyName}' already exists`);
+      const duplicate = await this.dynamoDb.get(duplicateCheckParams).promise();
+      if (duplicate.Item) {
+        this.logger.error(`Revenue item with name '${trimmedBodyName}' already exists`);
+        throw new BadRequestException(`A revenue item with the name '${trimmedBodyName}' already exists`);
+      }
+    } catch (error) {
+      if (error instanceof BadRequestException || error instanceof InternalServerErrorException) {
+        throw error;
+      }
+      if (this.isAWSError(error)) {
+        this.logger.error('AWS error during duplicate check for updateRevenue: ', error);
+        throw new InternalServerErrorException('Internal Server Error');
+      }
+      this.logger.error('Uncaught error checking for duplicate revenue item on update: ', error);
+      throw new InternalServerErrorException('Internal Server Error');
+    }
+  }
+
   // Put replaces the entire item at the given key with the new values
-  const putParams = {
+  const putParams: AWS.DynamoDB.DocumentClient.PutItemInput = {
     TableName: this.revenueTableName,
     Item: normalizedRevenue,
   };
+
+  if (isRename) {
+    putParams.ConditionExpression = 'attribute_not_exists(#name)';
+    putParams.ExpressionAttributeNames = { '#name': 'name' };
+  }
 
   this.logger.log(`Params for update call to dynamo db: ${JSON.stringify(putParams, null, 2)}`);
 
@@ -392,6 +431,12 @@ async updateRevenue(name: string, revenue: CashflowRevenue): Promise<CashflowRev
   } catch (error) {
     if (error instanceof BadRequestException || error instanceof InternalServerErrorException) {
       throw error;
+    }
+    if (this.isAWSError(error)) {
+      const awsError = error as { code?: string };
+      if (awsError.code === 'ConditionalCheckFailedException') {
+        throw new BadRequestException(`A revenue item with the name '${trimmedBodyName}' already exists`);
+      }
     }
     if (this.isAWSError(error)) {
       this.logger.error('AWS error during updateRevenue: ', error);


### PR DESCRIPTION
### ℹ️ Issue #408 

Closes #408 

### 📝 Description

Briefly list the changes made to the code:
1. Checks if the revenue route exists
2. Throws error if the revenue route doesn't exist, so you cannot update anything
3. Checks if the revenue name is a duplicate
4. Throws error if the revenue name is a duplicate
5. If the revenue name is changed, delete the old one

### ✔️ Verification
<img width="564" height="706" alt="Screenshot 2026-04-12 at 4 00 41 PM" src="https://github.com/user-attachments/assets/b743f66e-6480-4db9-86cf-5e63e0bf00ff" />

<img width="891" height="661" alt="Screenshot 2026-04-12 at 4 02 15 PM" src="https://github.com/user-attachments/assets/0a115b78-e517-42ca-928c-c23054b4dd45" />